### PR TITLE
顧客ページ実装

### DIFF
--- a/app/controllers/public/customers_controller.rb
+++ b/app/controllers/public/customers_controller.rb
@@ -1,10 +1,38 @@
 class Public::CustomersController < ApplicationController
+  
   def show
+    @customer = current_customer
   end
 
   def edit
+    @customer = current_customer
+  end
+
+  def update
+    @customer = current_customer
+    if @customer.update(customer_params)
+      redirect_to public_customer_path
+    else
+      redirect_to public_customer_edit_path
+    end
   end
 
   def confirm
   end
+  
+  def withdrawal
+    @customer = current_customer
+    @customer.update(is_deleted: true)
+    reset_session
+    flash[:notice] = "退会処理を完了しました。"
+    redirect_to root_path
+  end
+
+  private
+  
+  def customer_params
+    params.require(:customer).permit(:last_name, :first_name, :kana_last_name, :kana_first_name, :email, :post_code, :address, :phone_number)
+  end
+
+
 end

--- a/app/controllers/public/customers_controller.rb
+++ b/app/controllers/public/customers_controller.rb
@@ -1,5 +1,5 @@
 class Public::CustomersController < ApplicationController
-  
+
   def show
     @customer = current_customer
   end
@@ -11,25 +11,27 @@ class Public::CustomersController < ApplicationController
   def update
     @customer = current_customer
     if @customer.update(customer_params)
+      flash[:notice] = "会員情報変更しました。"
       redirect_to public_customer_path
     else
+      flash[:notice] = "変更内容が正しくありません。"
       redirect_to public_customer_edit_path
     end
   end
 
   def confirm
   end
-  
+
   def withdrawal
     @customer = current_customer
     @customer.update(is_deleted: true)
     reset_session
-    flash[:notice] = "退会処理を完了しました。"
+    flash[:notice] = "退会処理を完了しました。ご利用ありがとうございました。"
     redirect_to root_path
   end
 
   private
-  
+
   def customer_params
     params.require(:customer).permit(:last_name, :first_name, :kana_last_name, :kana_first_name, :email, :post_code, :address, :phone_number)
   end

--- a/app/controllers/public/sessions_controller.rb
+++ b/app/controllers/public/sessions_controller.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
 class Public::SessionsController < Devise::SessionsController
-  # before_action :configure_sign_in_params, only: [:create]
+  before_action :customer_state, only: [:create]
 
   def after_sign_in_path_for(resource)
     root_path
   end
 
+  def after_sign_out_path_for(resouce)
+    root_path
+  end
   # GET /resource/sign_in
   # def new
   #   super
@@ -22,7 +25,21 @@ class Public::SessionsController < Devise::SessionsController
   #   super
   # end
 
-  # protected
+  protected
+
+  def customer_state
+    @customer = Customer.find_by(email: params[:customer][:email])
+      if !@customer
+        if @customer.valid_password?(params[:customer][:email]) && (@customer.is_deleted == true)
+          flash[:notice] = "退会済みです。"
+          redirect_to new_customer_registration_path
+        else
+          flash[:notice] = "項目を入力してください。"
+        end
+      else
+      flash[:notice] = "該当するユーザーがみつかりません。"
+      end
+  end
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_in_params

--- a/app/controllers/public/sessions_controller.rb
+++ b/app/controllers/public/sessions_controller.rb
@@ -27,18 +27,14 @@ class Public::SessionsController < Devise::SessionsController
 
   protected
 
+  # 退会済みの会員がログインできない機能
   def customer_state
     @customer = Customer.find_by(email: params[:customer][:email])
-      if !@customer
-        if @customer.valid_password?(params[:customer][:email]) && (@customer.is_deleted == true)
-          flash[:notice] = "退会済みです。"
+    return if !@customer
+        if @customer.valid_password?(params[:customer][:password]) && (@customer.is_deleted == true)
+          flash[:notice] = "退会済みです。新たに会員登録するか、お問い合わせください。"
           redirect_to new_customer_registration_path
-        else
-          flash[:notice] = "項目を入力してください。"
         end
-      else
-      flash[:notice] = "該当するユーザーがみつかりません。"
-      end
   end
 
   # If you have extra params to permit, append them to the sanitizer.

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -9,11 +9,12 @@ class Customer < ApplicationRecord
   has_many :orders, dependent: :destroy
   has_many :addresses, dependent: :destroy
 
-
-  def active_for_authentication?
-    super && (is_deleted == false)
-  end
-
+  validates :last_name, presence: true
+  validates :first_name, presence: true
+  validates :kana_last_name, presence: true
+  validates :kana_first_name, presence: true
+  validates :post_code, presence: true
+  validates :address, presence: true
   validates :phone_number, uniqueness: true
 
 end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -9,6 +9,11 @@ class Customer < ApplicationRecord
   has_many :orders, dependent: :destroy
   has_many :addresses, dependent: :destroy
 
+
+  def active_for_authentication?
+    super && (is_deleted == false)
+  end
+
   validates :phone_number, uniqueness: true
 
 end

--- a/app/views/public/customers/confirm.html.erb
+++ b/app/views/public/customers/confirm.html.erb
@@ -1,2 +1,6 @@
-<h1>Public::Customers#confirm</h1>
-<p>Find me in app/views/public/customers/confirm.html.erb</p>
+<h3>本当に退会しますか？</h3>
+<p>退会すると、会員登録情報やこれまでの購入履歴が閲覧できなくなります。</p>
+<p>退会する場合は、「退会する」をクリックしてください。</p>
+
+<%= link_to "退会しない", public_customer_path, class: "btn btn-primary" %>
+<%= link_to "退会する", public_customer_withdrawal_path, method: :patch, class: "btn btn-danger", "data-confirm" => "本当に退会しますか？" %>

--- a/app/views/public/customers/edit.html.erb
+++ b/app/views/public/customers/edit.html.erb
@@ -1,2 +1,42 @@
-<h1>Public::Customers#edit</h1>
-<p>Find me in app/views/public/customers/edit.html.erb</p>
+<h1>会員情報編集</h1>
+
+<%= form_with model: @customer, url: public_customer_update_path do |f| %>
+
+  <div class="field">
+      <%= f.label :氏名 %>
+      <%= f.text_field :last_name, autofocus: true %>
+      <%= f.text_field :first_name %>
+  </div>
+
+  <div class="field">
+    <%= f.label :フリガナ %>
+    <%= f.text_field :kana_last_name %>
+    <%= f.text_field :kana_first_name %>
+  </div>
+
+  <div class="field">
+    <%= f.label :メールアドレス %>
+    <%= f.email_field :email, autocomplete: "email" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :郵便番号（ハイフンなし） %>
+    <%= f.text_field :post_code %>
+  </div>
+
+  <div class="field">
+    <%= f.label :住所 %>
+    <%= f.text_field :address %>
+  </div>
+
+  <div class="field">
+    <%= f.label :電話番号（ハイフンなし） %>
+    <%= f.text_field :phone_number %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "編集内容を保存", class: "btn btn-success" %>
+  </div>
+<% end %>
+
+<%= link_to "退会する", public_customer_confirm_path, class: "btn btn-danger" %>

--- a/app/views/public/customers/show.html.erb
+++ b/app/views/public/customers/show.html.erb
@@ -1,2 +1,40 @@
-<h1>Public::Customers#show</h1>
-<p>Find me in app/views/public/customers/show.html.erb</p>
+<h1>マイページ</h1>
+
+<span>登録情報</span>
+
+<%= link_to "編集する", public_customer_edit_path, class: "btn btn-success" %>
+
+<table class="table-bordered">
+  <thead></thead>
+  <tbody>
+    <tr>
+      <td class="table-active">氏名</td>
+      <td><%= @customer.last_name %>&nbsp;<%= @customer.first_name %></td>
+    </tr>
+    <tr>
+      <td class="table-active">カナ</td>
+      <td><%= @customer.kana_last_name %>&nbsp;<%= @customer.kana_first_name %></td>
+    </tr>
+    <tr>
+      <td class="table-active">郵便番号</td>
+      <td><%= @customer.post_code %></td>
+    <tr>
+      <td class="table-active">住所</td>
+      <td><%= @customer.address %></td>
+    </tr>
+    <tr>
+      <td class="table-active">電話番号</td>
+      <td><%= @customer.phone_number %></td>
+    </tr>
+    <tr>
+      <td class="table-active">メールアドレス</td>
+      <td><%= @customer.email %></td>
+    </tr>
+  </tbody>
+</table>
+
+<span strong>配送先</span>
+<%= link_to "一覧を見る", public_addresses_path, class: "btn btn-primary" %>
+
+<span>注文履歴</span>
+<%= link_to "一覧を見る", public_orders_path, class: "btn btn-primary" %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -35,10 +35,6 @@ ActiveRecord::Schema.define(version: 2023_09_16_072208) do
   end
 
   create_table "customers", force: :cascade do |t|
-<<<<<<< HEAD
-=======
-
->>>>>>> origin/develop
     t.string "last_name", null: false
     t.string "first_name", null: false
     t.string "kana_last_name", null: false


### PR DESCRIPTION
顧客ページ（public/customers）
顧客のマイページ
顧客の登録情報編集画面
顧客の登録情報更新
顧客の退会確認画面
顧客の退会処理(ステータスの更新)

追加で、顧客情報新規登録時、各項目バリデーション空でない状態に設定しました。
レイアウトは設定していません。
確認お願いします。